### PR TITLE
Handle IPv6 URIs properly

### DIFF
--- a/wyoming/server.py
+++ b/wyoming/server.py
@@ -64,9 +64,9 @@ class AsyncServer(ABC):
             return AsyncUnixServer(result.path)
 
         if result.scheme == "tcp":
-            host, port_str = result.netloc.split(":")
-            port = int(port_str)
-            return AsyncTcpServer(host, port)
+            if result.port is not None:
+                raise ValueError("A port must be specified when using a 'tcp://' URI")
+            return AsyncTcpServer(result.hostname, result.port)
 
         if result.scheme == "stdio":
             return AsyncStdioServer()


### PR DESCRIPTION
Wyoming's server implementation currently doesn't support ipv6 URI's; indeed, trying to pass one in results in the following trace:
```
File "/usr/local/lib/python3.9/dist-packages/wyoming/server.py", line 67, in from_uri

    host, port_str = result.netloc.split(":")

ValueError: too many values to unpack (expected 2)
```

Doing string.split on the netloc is a horrible way of handling parsing URIs, so I propose using the library's built in parser instead. This should be able to properly ascertain the address without breaking if a hostname contains a colon.