### PR TITLE
add start_stage to run-satellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Play audio stream.
 Control of one or more remote voice satellites connected to a central server.
 
 * `run-satellite` - informs satellite that server is ready to run pipelines
+    * `start_stage` - request pipelines with a specific starting stage (string, optional)
 * `pause-satellite` - informs satellite that server is not ready anymore to run pipelines
 * `satellite-connected` - satellite has connected to the server
 * `satellite-disconnected` - satellite has been disconnected from the server

--- a/wyoming/satellite.py
+++ b/wyoming/satellite.py
@@ -1,7 +1,9 @@
 """Satellite events."""
 from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 from .event import Event, Eventable
+from .pipeline import PipelineStage
 
 _RUN_SATELLITE_TYPE = "run-satellite"
 _PAUSE_SATELLITE_TYPE = "pause-satellite"
@@ -15,16 +17,28 @@ _SATELLITE_DISCONNECTED_TYPE = "satellite-disconnected"
 class RunSatellite(Eventable):
     """Informs the satellite that the server is ready to run a pipeline."""
 
+    start_stage: Optional[PipelineStage] = None
+
     @staticmethod
     def is_type(event_type: str) -> bool:
         return event_type == _RUN_SATELLITE_TYPE
 
     def event(self) -> Event:
-        return Event(type=_RUN_SATELLITE_TYPE)
+        data: Dict[str, Any] = {}
+
+        if self.start_stage is not None:
+            data["start_stage"] = self.start_stage.value
+
+        return Event(type=_RUN_SATELLITE_TYPE, data=data)
 
     @staticmethod
     def from_event(event: Event) -> "RunSatellite":
-        return RunSatellite()
+        # note: older versions don't send event.data
+        start_stage = None
+        if value := (event.data or {}).get("start_stage"):
+            start_stage = PipelineStage(value)
+
+        return RunSatellite(start_stage=start_stage)
 
 
 @dataclass


### PR DESCRIPTION
This PR adds an optional `start_stage` param to `run-satellite`.

The main use is in a "push to talk" feature I am preparing that allows a satellite to be "activated" from the server side. In this case the server will send `run-satellite` with `start_stage = asr` to indicate that it wants the satellite to start a pipeline going directly to ASR (skipping vad / wake word / etc). More details will be provided in the corresponding PR in `home-assistant/core`.

But there could be other uses. `run-satellite` indicates that the server is ready to run pipelines, it makes sense to be able to specify specific properties of these pipelines.

The param is optional, if `None` the satellite chooses the starting stage, as it happens now.