### PR TITLE
Fix for conversion of 8-bit audio

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -23,6 +23,34 @@ def test_chunk_converter() -> None:
     assert len(output_chunk.audio) == 1 * 16000 * 2 * 1  # 1 sec
 
 
+def test_chunk_converter_8bit() -> None:
+    """Test conversion to/from unsigned 8-bit audio.
+
+    WAV 8-bit samples are unsigned (silence = 128), unlike wider samples which
+    are signed (silence = 0). The converter must account for this.
+    """
+    # Unsigned 8-bit: silence, max, min, and a positive value
+    audio_8bit = bytes([128, 255, 0, 192])
+
+    # 8-bit -> 16-bit: silence must map to 0, not full-scale noise
+    to_16bit = AudioChunkConverter(width=2)
+    chunk_16bit = to_16bit.convert(
+        AudioChunk(rate=16000, width=1, channels=1, audio=audio_8bit)
+    )
+    assert chunk_16bit.width == 2
+    samples_16bit = [
+        int.from_bytes(chunk_16bit.audio[i : i + 2], "little", signed=True)
+        for i in range(0, len(chunk_16bit.audio), 2)
+    ]
+    assert samples_16bit[0] == 0  # unsigned silence -> signed silence
+
+    # 16-bit -> 8-bit round-trips back to the original unsigned bytes
+    to_8bit = AudioChunkConverter(width=1)
+    chunk_8bit = to_8bit.convert(chunk_16bit)
+    assert chunk_8bit.width == 1
+    assert chunk_8bit.audio == audio_8bit
+
+
 def test_wav_to_chunks() -> None:
     """Test WAV file to audio chunks."""
     with io.BytesIO() as wav_io:

--- a/tests/test_pyaudioop.py
+++ b/tests/test_pyaudioop.py
@@ -31,6 +31,29 @@ INVALID_DATA = [
 ]
 
 
+def test_bias() -> None:
+    """Test adding a bias to samples."""
+    for w in 1, 2, 4:
+        for bias in 0, 1, -1, 127, -128, 0x7FFFFFFF, -0x80000000:
+            assert pyaudioop.bias(b"", w, bias) == b""
+
+    assert pyaudioop.bias(datas[1], 1, 1) == b"\x01\x13\x46\xbc\x80\x81\x00"
+    assert pyaudioop.bias(datas[1], 1, -1) == b"\xff\x11\x44\xba\x7e\x7f\xfe"
+    assert pyaudioop.bias(datas[1], 1, 0x7FFFFFFF) == b"\xff\x11\x44\xba\x7e\x7f\xfe"
+    assert pyaudioop.bias(datas[1], 1, -0x80000000) == datas[1]
+
+    assert pyaudioop.bias(datas[2], 2, 1) == packs[2](
+        1, 0x1235, 0x4568, -0x4566, -0x8000, -0x7FFF, 0
+    )
+    assert pyaudioop.bias(datas[4], 4, 1) == packs[4](
+        1, 0x12345679, 0x456789AC, -0x456789AA, -0x80000000, -0x7FFFFFFF, 0
+    )
+
+    # Accepts bytearray and memoryview like the other functions
+    assert pyaudioop.bias(bytearray(datas[1]), 1, 1) == b"\x01\x13\x46\xbc\x80\x81\x00"
+    assert pyaudioop.bias(memoryview(datas[1]), 1, 1) == b"\x01\x13\x46\xbc\x80\x81\x00"
+
+
 def test_lin2lin() -> None:
     """Test sample width conversions."""
     for w in 1, 2, 4:

--- a/wyoming/audio.py
+++ b/wyoming/audio.py
@@ -163,7 +163,11 @@ class AudioChunkConverter:
 
         if (self.width is not None) and (chunk.width != self.width):
             # Convert sample width
+            if chunk.width == 1:
+                audio_bytes = audioop.bias(audio_bytes, 1, -128)
             audio_bytes = audioop.lin2lin(audio_bytes, chunk.width, self.width)
+            if self.width == 1:
+                audio_bytes = audioop.bias(audio_bytes, 1, 128)
             width = self.width
 
         channels = chunk.channels

--- a/wyoming/audio.py
+++ b/wyoming/audio.py
@@ -161,7 +161,11 @@ class AudioChunkConverter:
 
         if (self.width is not None) and (chunk.width != self.width):
             # Convert sample width
+            if chunk.width == 1:
+                audio_bytes = audioop.bias(audio_bytes, 1, -128)
             audio_bytes = audioop.lin2lin(audio_bytes, chunk.width, self.width)
+            if self.width == 1:
+                audio_bytes = audioop.bias(audio_bytes, 1, 128)
             width = self.width
 
         channels = chunk.channels

--- a/wyoming/pyaudioop.py
+++ b/wyoming/pyaudioop.py
@@ -3,7 +3,7 @@
 Only supports:
   - widths 1, 2, and 4
   - signed samples
-  - tomono, tostereo, lin2lin, ratecv
+  - bias, tomono, tostereo, lin2lin, ratecv
 """
 
 import math
@@ -131,6 +131,24 @@ def _set_sample32(
         struct.pack_into(_get_struct_format(width, endian), fragment, index, sample)
     else:
         raise ValueError(f"Invalid width: {width}")
+
+
+def bias(
+    fragment: BufferType, width: int, bias: int, endian: Endian = "little"
+) -> BufferType:
+    fragment_length = len(fragment)
+    check_parameters(fragment_length, width)
+
+    result = bytearray(fragment_length)
+    mask = (1 << (8 * width)) - 1
+
+    for i in range(0, fragment_length, width):
+        # Add bias with wrap-around on overflow, matching audioop.bias.
+        sample = int.from_bytes(fragment[i : i + width], endian)
+        sample = (sample + bias) & mask
+        result[i : i + width] = sample.to_bytes(width, endian)
+
+    return result
 
 
 def lin2lin(


### PR DESCRIPTION
When converting wave audio that is 8 bit (either input or output format) with audioop we need to care about the signedness of the 8-bit audio (see docs for audioop.lin2lin)