### PR TITLE
make lin2lin endian-aware for big-endian systems

### DIFF
--- a/tests/test_pyaudioop.py
+++ b/tests/test_pyaudioop.py
@@ -1,15 +1,13 @@
-import sys
-
 from wyoming import pyaudioop
 
 
-def pack(width, data):
-    return b"".join(v.to_bytes(width, sys.byteorder, signed=True) for v in data)
+def pack(width, data, endian="little"):
+    return b"".join(v.to_bytes(width, endian, signed=True) for v in data)
 
 
-def unpack(width, data):
+def unpack(width, data, endian="little"):
     return [
-        int.from_bytes(data[i : i + width], sys.byteorder, signed=True)
+        int.from_bytes(data[i : i + width], endian, signed=True)
         for i in range(0, len(data), width)
     ]
 
@@ -53,6 +51,31 @@ def test_lin2lin() -> None:
     assert pyaudioop.lin2lin(datas[4], 4, 1) == b"\x00\x12\x45\xba\x7f\x80\xff"
     assert pyaudioop.lin2lin(datas[4], 4, 2) == packs[2](
         0, 0x1234, 0x4567, -0x4568, 0x7FFF, -0x8000, -1
+    )
+
+
+def test_lin2lin_big_endian() -> None:
+    """Test sample width conversions with big-endian samples."""
+    data2 = pack(2, (0, 0x1234, 0x4567, -0x4567, 0x7FFF, -0x8000, -1), endian="big")
+    data4 = pack(
+        4,
+        (0, 0x12345678, 0x456789AB, -0x456789AB, 0x7FFFFFFF, -0x80000000, -1),
+        endian="big",
+    )
+
+    assert pyaudioop.lin2lin(data2, 2, 1, endian="big") == (
+        b"\x00\x12\x45\xba\x7f\x80\xff"
+    )
+    assert pyaudioop.lin2lin(data2, 2, 4, endian="big") == pack(
+        4,
+        (0, 0x12340000, 0x45670000, -0x45670000, 0x7FFF0000, -0x80000000, -0x10000),
+        endian="big",
+    )
+    assert pyaudioop.lin2lin(data4, 4, 1, endian="big") == (
+        b"\x00\x12\x45\xba\x7f\x80\xff"
+    )
+    assert pyaudioop.lin2lin(data4, 4, 2, endian="big") == pack(
+        2, (0, 0x1234, 0x4567, -0x4568, 0x7FFF, -0x8000, -1), endian="big"
     )
 
 

--- a/wyoming/pyaudioop.py
+++ b/wyoming/pyaudioop.py
@@ -88,34 +88,34 @@ def tostereo(
 
 
 def _get_sample32(fragment: BufferType, width: int, index: int) -> int:
+    """Extract a sample and convert it to 32-bit representation."""
     if width == 1:
-        return fragment[index]
+        # Use struct to handle signed byte properly
+        return struct.unpack_from('b', fragment, index)[0] << 24
 
-    if width == 2:
-        return (fragment[index] << 8) + (fragment[index + 1])
+    elif width == 2:
+        # Use struct to handle signed 16-bit with native byte order
+        return struct.unpack_from('h', fragment, index)[0] << 16
 
-    if width == 4:
-        return (
-            (fragment[index] << 24)
-            + (fragment[index + 1] << 16)
-            + (fragment[index + 2] << 8)
-            + fragment[index + 3]
-        )
+    elif width == 4:
+        # Use struct to handle signed 32-bit with native byte order
+        return struct.unpack_from('i', fragment, index)[0]
 
     raise ValueError(f"Invalid width: {width}")
 
-
 def _set_sample32(fragment: bytearray, width: int, index: int, sample: int) -> None:
+    """Set a sample from 32-bit representation."""
     if width == 1:
-        fragment[index] = sample & 0x000000FF
+        # Scale down from 32-bit and pack as signed byte
+        val = sample >> 24
+        struct.pack_into('b', fragment, index, val)
     elif width == 2:
-        fragment[index] = (sample >> 8) & 0x000000FF
-        fragment[index + 1] = sample & 0x000000FF
+        # Scale down from 32-bit and pack as signed 16-bit
+        val = sample >> 16
+        struct.pack_into('h', fragment, index, val)
     elif width == 4:
-        fragment[index] = sample >> 24
-        fragment[index + 1] = (sample >> 16) & 0x000000FF
-        fragment[index + 2] = (sample >> 8) & 0x000000FF
-        fragment[index + 3] = sample & 0x000000FF
+        # Pack as signed 32-bit
+        struct.pack_into('i', fragment, index, sample)
     else:
         raise ValueError(f"Invalid width: {width}")
 

--- a/wyoming/pyaudioop.py
+++ b/wyoming/pyaudioop.py
@@ -8,9 +8,10 @@ Only supports:
 
 import math
 import struct
-from typing import Final, List, Optional, Tuple, Union
+from typing import Final, List, Literal, Optional, Tuple, Union
 
 BufferType = Union[bytes, bytearray]
+Endian = Literal["big", "little"]
 State = Tuple[int, Tuple[Tuple[int, ...], ...]]
 
 # width = (_, 1, 2, _, 4)
@@ -18,6 +19,7 @@ _MAX_VALS: Final = [0, 0x7F, 0x7FFF, 0, 0x7FFFFFFF]
 _MIN_VALS: Final = [0, -0x80, -0x8000, 0, -0x80000000]
 _SIGNED_FORMATS: Final = ["", "b", "h", "", "i"]
 _UNSIGNED_FORMATS: Final = ["", "B", "H", "", "I"]
+_ENDIAN_FORMAT_PREFIX: Final = {"big": ">", "little": "<"}
 
 
 def check_size(size: int) -> None:
@@ -32,6 +34,17 @@ def check_parameters(fragment_length: int, size: int) -> None:
             "Not a whole number of frames: "
             f"fragment_length={fragment_length}, size={size}"
         )
+
+
+def _get_struct_format(width: int, endian: Endian) -> str:
+    struct_format = _SIGNED_FORMATS[width]
+    if width == 1:
+        return struct_format
+
+    try:
+        return _ENDIAN_FORMAT_PREFIX[endian] + struct_format
+    except KeyError as err:
+        raise ValueError(f"Endian should be 'big' or 'little'. Got {endian}") from err
 
 
 def fbound(val: float, min_val: float, max_val: float) -> int:
@@ -87,40 +100,42 @@ def tostereo(
     return result
 
 
-def _get_sample32(fragment: BufferType, width: int, index: int) -> int:
+def _get_sample32(fragment: BufferType, width: int, index: int, endian: Endian) -> int:
     """Extract a sample and convert it to 32-bit representation."""
     if width == 1:
-        # Use struct to handle signed byte properly
-        return struct.unpack_from('b', fragment, index)[0] << 24
+        return struct.unpack_from("b", fragment, index)[0] << 24
 
-    elif width == 2:
-        # Use struct to handle signed 16-bit with native byte order
-        return struct.unpack_from('h', fragment, index)[0] << 16
+    if width == 2:
+        return (
+            struct.unpack_from(_get_struct_format(width, endian), fragment, index)[0]
+            << 16
+        )
 
-    elif width == 4:
-        # Use struct to handle signed 32-bit with native byte order
-        return struct.unpack_from('i', fragment, index)[0]
+    if width == 4:
+        return struct.unpack_from(_get_struct_format(width, endian), fragment, index)[0]
 
     raise ValueError(f"Invalid width: {width}")
 
-def _set_sample32(fragment: bytearray, width: int, index: int, sample: int) -> None:
+
+def _set_sample32(
+    fragment: bytearray, width: int, index: int, sample: int, endian: Endian
+) -> None:
     """Set a sample from 32-bit representation."""
     if width == 1:
-        # Scale down from 32-bit and pack as signed byte
-        val = sample >> 24
-        struct.pack_into('b', fragment, index, val)
+        struct.pack_into("b", fragment, index, sample >> 24)
     elif width == 2:
-        # Scale down from 32-bit and pack as signed 16-bit
-        val = sample >> 16
-        struct.pack_into('h', fragment, index, val)
+        struct.pack_into(
+            _get_struct_format(width, endian), fragment, index, sample >> 16
+        )
     elif width == 4:
-        # Pack as signed 32-bit
-        struct.pack_into('i', fragment, index, sample)
+        struct.pack_into(_get_struct_format(width, endian), fragment, index, sample)
     else:
         raise ValueError(f"Invalid width: {width}")
 
 
-def lin2lin(fragment: BufferType, width: int, new_width: int) -> BufferType:
+def lin2lin(
+    fragment: BufferType, width: int, new_width: int, endian: Endian = "little"
+) -> BufferType:
     if width == new_width:
         return fragment
 
@@ -132,8 +147,8 @@ def lin2lin(fragment: BufferType, width: int, new_width: int) -> BufferType:
 
     j = 0
     for i in range(0, fragment_length, width):
-        sample = _get_sample32(fragment, width, i)
-        _set_sample32(result, new_width, j, sample)
+        sample = _get_sample32(fragment, width, i, endian)
+        _set_sample32(result, new_width, j, sample, endian)
         j += new_width
 
     return result


### PR DESCRIPTION
The _get_sample32 and _set_sample32 functions in pyaudioop.py were using hardcoded little-endian byte manipulation, causing test failures on big-endian architectures like s390x.

Replace manual byte operations with struct.pack_into/unpack_from using native byte order format characters ('b', 'h', 'i').

Fixes test failure: test_pyaudioop.py::test_lin2lin on s390x