### PR TITLE
Handle connection errors during event writes

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,11 @@
 """Server tests."""
 
 import asyncio
+import logging
 import socket
 import tempfile
 from pathlib import Path
+from typing import List, Optional
 
 import pytest
 
@@ -116,3 +118,136 @@ async def test_tcp_server() -> None:
 
     await client.disconnect()
     await tcp_server.stop()
+
+
+class DisconnectAwareHandler(AsyncEventHandler):
+    """Handler that records the exception raised by write_event on disconnect."""
+
+    def __init__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        super().__init__(reader, writer)
+        self.write_error: Optional[BaseException] = None
+
+    async def handle_event(self, event: Event) -> bool:
+        # Repeatedly write until the client disconnects so we hit drain().
+        try:
+            while True:
+                await self.write_event(Pong(text="x" * 4096).event())
+                await asyncio.sleep(0)
+        except BaseException as err:
+            self.write_error = err
+            raise
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_propagates_to_handler(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A client disconnect mid-write should surface to handle_event and not
+    leave an unretrieved task exception or emit an error log."""
+    handlers: List[DisconnectAwareHandler] = []
+
+    def factory(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> DisconnectAwareHandler:
+        handler = DisconnectAwareHandler(reader, writer)
+        handlers.append(handler)
+        return handler
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    port = sock.getsockname()[1]
+    sock.close()
+
+    uri = f"tcp://127.0.0.1:{port}"
+    tcp_server = AsyncServer.from_uri(uri)
+    await tcp_server.start(factory)
+
+    client = AsyncClient.from_uri(uri)
+    for _ in range(10):
+        try:
+            await client.connect()
+            break
+        except ConnectionRefusedError:
+            await asyncio.sleep(0.1)
+    await client.write_event(Ping(text="trigger").event())
+
+    # Wait for at least one Pong so we know the server has entered the
+    # write loop in handle_event before we abort the connection.
+    pong = await asyncio.wait_for(client.read_event(), timeout=2)
+    assert pong is not None and Pong.is_type(pong.type)
+
+    # Capture the server task before severing the connection.
+    server_tasks = list(tcp_server._handlers)
+    assert server_tasks, "Server never created a handler task"
+    server_task = server_tasks[0]
+
+    # Hard-close the client to provoke a write failure on the server side.
+    assert client._writer is not None
+    client._writer.transport.abort()
+    await client.disconnect()
+
+    # Wait for the server task to complete, then let _handler_done run.
+    await asyncio.wait({server_task}, timeout=2)
+    assert server_task.done(), "Server task did not complete in time"
+    await asyncio.sleep(0)
+
+    # The write_event call inside handle_event should have raised so
+    # handle_event can react to the disconnect.
+    assert handlers, "Handler was never instantiated"
+    handler = handlers[0]
+    assert handler.write_error is not None
+    assert isinstance(handler.write_error, ConnectionError)
+
+    # No "Unhandled exception" log should have been emitted for a normal
+    # client disconnect.
+    unhandled = [
+        record
+        for record in caplog.get_records("call")
+        if record.levelno >= logging.ERROR
+        and "Unhandled exception" in record.getMessage()
+    ]
+    assert not unhandled, unhandled
+
+    await tcp_server.stop()
+
+
+@pytest.mark.asyncio
+async def test_handler_done_silences_incomplete_read(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """asyncio.IncompleteReadError surfaces when a client disconnects
+    mid-readexactly. _handler_done must treat it as an expected disconnect
+    and not log it as 'Unhandled exception'."""
+
+    class _ReadingHandler(AsyncEventHandler):
+        async def handle_event(self, event: Event) -> bool:
+            return True
+
+    tcp_server = AsyncTcpServer("127.0.0.1", 0)
+
+    # Simulate a completed handler task that raised IncompleteReadError,
+    # exercising _handler_done in isolation.
+    async def raises_incomplete_read() -> None:
+        raise asyncio.IncompleteReadError(partial=b"", expected=1)
+
+    task = asyncio.create_task(raises_incomplete_read())
+    tcp_server._handlers[task] = _ReadingHandler(  # type: ignore[arg-type]
+        asyncio.StreamReader(), None  # type: ignore[arg-type]
+    )
+    task.add_done_callback(tcp_server._handler_done)
+
+    with pytest.raises(asyncio.IncompleteReadError):
+        await task
+    await asyncio.sleep(0)  # let done-callback run
+
+    unhandled = [
+        record
+        for record in caplog.get_records("call")
+        if record.levelno >= logging.ERROR
+        and "Unhandled exception" in record.getMessage()
+    ]
+    assert not unhandled, unhandled
+    assert task not in tcp_server._handlers

--- a/wyoming/event.py
+++ b/wyoming/event.py
@@ -134,7 +134,7 @@ async def async_write_event(event: Event, writer: asyncio.StreamWriter):
             writer.write(event.payload)
 
         await writer.drain()
-    except (KeyboardInterrupt, ConnectionResetError, ConnectionError, BrokenPipeError):
+    except KeyboardInterrupt:
         pass
 
 

--- a/wyoming/event.py
+++ b/wyoming/event.py
@@ -134,7 +134,7 @@ async def async_write_event(event: Event, writer: asyncio.StreamWriter):
             writer.write(event.payload)
 
         await writer.drain()
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, ConnectionResetError, ConnectionError, BrokenPipeError):
         pass
 
 

--- a/wyoming/server.py
+++ b/wyoming/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import sys
 from abc import ABC, abstractmethod
 from functools import partial
@@ -7,6 +8,8 @@ from typing import Callable, Dict, Optional, Union
 from urllib.parse import urlparse
 
 from .event import Event, async_get_stdin, async_read_event, async_write_event
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AsyncEventHandler(ABC):
@@ -40,8 +43,6 @@ class AsyncEventHandler(ABC):
 
                 if not (await self.handle_event(event)):
                     break
-        except (ConnectionResetError, ConnectionError, BrokenPipeError):
-            pass
         finally:
             await self.disconnect()
 
@@ -98,7 +99,18 @@ class AsyncServer(ABC):
         handler = handler_factory(reader, writer)
         task = asyncio.create_task(handler.run(), name="wyoming event handler")
         self._handlers[task] = handler
-        task.add_done_callback(lambda t: self._handlers.pop(t, None))
+        task.add_done_callback(self._handler_done)
+
+    def _handler_done(self, task: asyncio.Task) -> None:
+        self._handlers.pop(task, None)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None or isinstance(
+            exc, (ConnectionError, asyncio.IncompleteReadError)
+        ):
+            return
+        _LOGGER.exception("Unhandled exception in Wyoming event handler", exc_info=exc)
 
     async def start(self, handler_factory: HandlerFactory) -> None:
         """Start server without blocking."""

--- a/wyoming/server.py
+++ b/wyoming/server.py
@@ -40,6 +40,8 @@ class AsyncEventHandler(ABC):
 
                 if not (await self.handle_event(event)):
                     break
+        except (ConnectionResetError, ConnectionError, BrokenPipeError):
+            pass
         finally:
             await self.disconnect()
 


### PR DESCRIPTION
I see this error pretty much every time I restart the openWakeWord app in Home Assistant:

```
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='wyoming event handler' coro=<AsyncEventHandler.run() done, defined at /usr/local/lib/python3.11/dist-packages/wyoming/server.py:31> exception=ConnectionResetError('Connection lost')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/wyoming/server.py", line 41, in run
    if not (await self.handle_event(event)):
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/wyoming_openwakeword/handler.py", line 62, in handle_event
    await self.write_event(info.event())
  File "/usr/local/lib/python3.11/dist-packages/wyoming/server.py", line 29, in write_event
    await async_write_event(event, self.writer)
  File "/usr/local/lib/python3.11/dist-packages/wyoming/event.py", line 136, in async_write_event
    await writer.drain()
  File "/usr/lib/python3.11/asyncio/streams.py", line 378, in drain
    await self._protocol._drain_helper()
  File "/usr/lib/python3.11/asyncio/streams.py", line 167, in _drain_helper
    raise ConnectionResetError('Connection lost')
ConnectionResetError: Connection lost
[16:53:33] INFO: Successfully sent discovery information to Home Assistant.
```

Did a bit of digging, tracked it down to this. Commit message follows.

Add exception handling for ConnectionResetError, ConnectionError, and BrokenPipeError in both AsyncEventHandler.run() and async_write_event() to prevent "Task exception was never retrieved" errors when clients disconnect. Client disconnects are normal and shouldn't be treated as exceptional conditions.