### PR TITLE
Add identity recognition protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `wake_words` query parameter to wake server
 - Add identity recognition protocol support
+- Add identity enrollment and deletion events
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `wake_words` query parameter to wake server
 - Add identity recognition protocol support
 - Add identity enrollment and deletion events
+- Add identity support to pipelines
+- Add `identity_name` to pipeline state
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `wake_words` query parameter to wake server
+- Add identity recognition protocol support
 
 ## 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -324,9 +324,13 @@ Pipelines are run on the server, but can be triggered remotely from the server a
 
 * `run-pipeline` - runs a pipeline on the server or asks the satellite to run it when possible
     * `start_stage` - pipeline stage to start at (string, required)
+        * Valid stages: `wake`, `identity`, `asr`, `intent`, `handle`, `tts`
     * `end_stage` - pipeline stage to end at (string, required)
+        * Valid stages: `wake`, `identity`, `asr`, `intent`, `handle`, `tts`
     * `wake_word_name` - name of detected wake word that started this pipeline (string, optional)
         * From client only
+    * `identity_name` - name of recognized identity collected during the pipeline (string, optional)
+        * Stored as the result of the `identity` stage for later stages to use
     * `wake_word_names` - names of wake words to listen for (list of string, optional)
         * From server only
         * `start_stage` must be "wake"
@@ -335,6 +339,11 @@ Pipelines are run on the server, but can be triggered remotely from the server a
         * `start_stage` must be "tts"
     * `restart_on_end` - true if the server should re-run the pipeline after it ends (boolean, default is false)
         * Only used for always-on streaming satellites
+
+Valid pipeline order is:
+`wake -> {identity, asr} -> intent -> handle -> tts`
+
+`identity` and `asr` are parallel audio-analysis stages. Stages may be skipped, but pipelines must still move forward through this order.
 
 ### Timers
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Used in [Rhasspy](https://github.com/rhasspy/rhasspy3/) and [Home Assistant](htt
     * [Whisper.cpp](https://github.com/rhasspy/wyoming-whisper-cpp)
 * Text-to-speech
     * [Piper](https://github.com/rhasspy/wyoming-piper)
+* Identity recognition
+    * First planned implementation: pyannote-audio
 * Intent handling
     * [handle-external](https://github.com/rhasspy/wyoming-handle-external)
 
@@ -105,6 +107,17 @@ Describe available services.
             * `description` - human-readable description (string, optional)
             * `version` - version of the model (string, optional)
        * `supports_synthesize_streaming` - true if program can stream text chunks
+    * `identity` - list identity recognition services (optional)
+        * `models` - list of available models (required)
+            * `name` - unique name (required)
+            * `identities` - list of enrolled identities (optional)
+                * `name` - unique name of identity (required)
+            * `attribution` (required)
+                * `name` - name of creator (required)
+                * `url` - URL of creator (required)
+            * `installed` - true if currently installed (bool, required)
+            * `description` - human-readable description (string, optional)
+            * `version` - version of the model (string, optional)
     * `wake` - list wake word detection services( optional )
         * `models` - list of available models (required)
             * `name` - unique name (required)
@@ -211,6 +224,21 @@ Detect wake words in an audio stream.
     * `name` - name of wake word that was detected (int, optional)
     * `timestamp` - timestamp of audio chunk in milliseconds when detection occurred (int optional)
 * `not-detected` - response when audio stream ends without a detection
+
+### Identity Recognition
+
+Identify a person from an audio stream.
+
+* `identify` - request identity recognition from an audio stream
+    * `name` - name of model to use (string, optional)
+    * `names` - identity names to consider (list of string, optional)
+    * `context` - context from previous interactions (object, optional)
+* `identified` - response when an identity is recognized
+    * `name` - name of identified identity (string, required)
+    * `confidence` - confidence score (number, optional)
+    * `context` - context for next interactions (object, optional)
+* `not-identified` - response when audio stream ends without a recognized identity
+    * `context` - context for next interactions (object, optional)
 
 ### Voice Activity Detection
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ Identify a person from an audio stream.
     * `context` - context for next interactions (object, optional)
 * `not-identified` - response when audio stream ends without a recognized identity
     * `context` - context for next interactions (object, optional)
+* `enroll` - request enrollment of a new identity from an audio stream
+    * `name` - name of identity to enroll (string, required)
+    * `model` - name of model to update (string, optional)
+    * `context` - context from previous interactions (object, optional)
+* `enrolled` - response when an identity has been enrolled
+    * `name` - name of enrolled identity (string, required)
+    * `model` - name of updated model (string, optional)
+    * `context` - context for next interactions (object, optional)
+* `delete` - request deletion of an enrolled identity
+    * `name` - name of identity to delete (string, required)
+    * `model` - name of model to update (string, optional)
+    * `context` - context from previous interactions (object, optional)
+* `deleted` - response when an identity has been deleted
+    * `name` - name of deleted identity (string, required)
+    * `model` - name of updated model (string, optional)
+    * `context` - context for next interactions (object, optional)
 
 ### Voice Activity Detection
 

--- a/tests/test_eventable.py
+++ b/tests/test_eventable.py
@@ -19,6 +19,9 @@ from wyoming.info import (
     HandleProgram,
     IntentModel,
     IntentProgram,
+    Identity,
+    IdentityModel,
+    IdentityProgram,
     MicProgram,
     Satellite,
     SndProgram,
@@ -115,6 +118,25 @@ TEST_DATA: Dict[str, Dict[str, Any]] = {
                     )
                 ],
                 supports_synthesize_streaming=True,
+            )
+        ],
+        "identity": [
+            IdentityProgram(
+                name=TEST_NAME,
+                attribution=TEST_ATTRIBUTION,
+                installed=True,
+                description=TEST_DESCRIPTION,
+                version=TEST_VERSION,
+                models=[
+                    IdentityModel(
+                        name=TEST_NAME,
+                        attribution=TEST_ATTRIBUTION,
+                        installed=True,
+                        description=TEST_DESCRIPTION,
+                        version=TEST_VERSION,
+                        identities=[Identity(TEST_SPEAKER)],
+                    )
+                ],
             )
         ],
         "handle": [
@@ -268,6 +290,18 @@ TEST_DATA: Dict[str, Dict[str, Any]] = {
     "SynthesizeStop": {},
     "SynthesizeStopped": {},
     "Synthesize": {"text": TEST_TEXT, "voice": TEST_VOICE, "context": TEST_CONTEXT},
+    # identity
+    "Identify": {
+        "name": TEST_NAME,
+        "names": [TEST_SPEAKER],
+        "context": TEST_CONTEXT,
+    },
+    "Identified": {
+        "name": TEST_SPEAKER,
+        "confidence": 0.9,
+        "context": TEST_CONTEXT,
+    },
+    "NotIdentified": {"context": TEST_CONTEXT},
     # timers
     "TimerStarted": {"id": TEST_ID, "total_seconds": 100},
     "TimerUpdated": {"id": TEST_ID, "total_seconds": 100, "is_active": True},

--- a/tests/test_eventable.py
+++ b/tests/test_eventable.py
@@ -17,11 +17,11 @@ from wyoming.info import (
     Attribution,
     HandleModel,
     HandleProgram,
-    IntentModel,
-    IntentProgram,
     Identity,
     IdentityModel,
     IdentityProgram,
+    IntentModel,
+    IntentProgram,
     MicProgram,
     Satellite,
     SndProgram,
@@ -340,7 +340,11 @@ TEST_DATA: Dict[str, Dict[str, Any]] = {
     "Error": {"text": TEST_TEXT},
     "Ping": {},
     "Pong": {},
-    "RunPipeline": {"start_stage": PipelineStage.ASR, "end_stage": PipelineStage.TTS},
+    "RunPipeline": {
+        "start_stage": PipelineStage.ASR,
+        "end_stage": PipelineStage.TTS,
+        "identity_name": TEST_SPEAKER,
+    },
 }
 
 

--- a/tests/test_eventable.py
+++ b/tests/test_eventable.py
@@ -302,6 +302,26 @@ TEST_DATA: Dict[str, Dict[str, Any]] = {
         "context": TEST_CONTEXT,
     },
     "NotIdentified": {"context": TEST_CONTEXT},
+    "Enroll": {
+        "name": TEST_SPEAKER,
+        "model": TEST_NAME,
+        "context": TEST_CONTEXT,
+    },
+    "Enrolled": {
+        "name": TEST_SPEAKER,
+        "model": TEST_NAME,
+        "context": TEST_CONTEXT,
+    },
+    "Delete": {
+        "name": TEST_SPEAKER,
+        "model": TEST_NAME,
+        "context": TEST_CONTEXT,
+    },
+    "Deleted": {
+        "name": TEST_SPEAKER,
+        "model": TEST_NAME,
+        "context": TEST_CONTEXT,
+    },
     # timers
     "TimerStarted": {"id": TEST_ID, "total_seconds": 100},
     "TimerUpdated": {"id": TEST_ID, "total_seconds": 100, "is_active": True},

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,29 @@
+"""Tests for pipeline stage validation."""
+
+import pytest
+
+from wyoming.pipeline import PipelineStage, RunPipeline
+
+
+def test_pipeline_identity_stage_valid() -> None:
+    """Identity stage is a peer of ASR before text stages."""
+    RunPipeline(start_stage=PipelineStage.WAKE, end_stage=PipelineStage.IDENTITY)
+    RunPipeline(start_stage=PipelineStage.IDENTITY, end_stage=PipelineStage.ASR)
+    RunPipeline(start_stage=PipelineStage.ASR, end_stage=PipelineStage.IDENTITY)
+    RunPipeline(start_stage=PipelineStage.IDENTITY, end_stage=PipelineStage.TTS)
+
+
+def test_pipeline_identity_stage_invalid() -> None:
+    """Identity stage cannot come after text stages."""
+    with pytest.raises(ValueError):
+        RunPipeline(start_stage=PipelineStage.INTENT, end_stage=PipelineStage.IDENTITY)
+
+
+def test_pipeline_identity_result_round_trip() -> None:
+    """Recognized identity is preserved in pipeline state."""
+    pipeline = RunPipeline(
+        start_stage=PipelineStage.ASR,
+        end_stage=PipelineStage.TTS,
+        identity_name="test-identity",
+    )
+    assert RunPipeline.from_event(pipeline.event()) == pipeline

--- a/wyoming/identity.py
+++ b/wyoming/identity.py
@@ -1,0 +1,113 @@
+"""Identity recognition."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .event import Event, Eventable
+
+DOMAIN = "identity"
+_IDENTIFY_TYPE = "identify"
+_IDENTIFIED_TYPE = "identified"
+_NOT_IDENTIFIED_TYPE = "not-identified"
+
+
+@dataclass
+class Identify(Eventable):
+    """Request to identify an identity from an audio stream.
+
+    Followed by AudioStart, AudioChunk+, AudioStop
+    """
+
+    name: Optional[str] = None
+    """Name of identity recognition model to use."""
+
+    names: Optional[List[str]] = None
+    """Names of identities to consider (None = any)."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context from previous interactions."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _IDENTIFY_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {}
+        if self.name is not None:
+            data["name"] = self.name
+        if self.names is not None:
+            data["names"] = self.names
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_IDENTIFY_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Identify":
+        data = event.data or {}
+        return Identify(
+            name=data.get("name"),
+            names=data.get("names"),
+            context=data.get("context"),
+        )
+
+
+@dataclass
+class Identified(Eventable):
+    """Identity was recognized."""
+
+    name: str
+    """Name/id of identified identity."""
+
+    confidence: Optional[float] = None
+    """Confidence score of the identification."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context for next interaction."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _IDENTIFIED_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.confidence is not None:
+            data["confidence"] = self.confidence
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_IDENTIFIED_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Identified":
+        return Identified(
+            name=event.data["name"],
+            confidence=event.data.get("confidence"),
+            context=event.data.get("context"),
+        )
+
+
+@dataclass
+class NotIdentified(Eventable):
+    """Audio stream ended before an identity could be recognized."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context for next interaction."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _NOT_IDENTIFIED_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {}
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_NOT_IDENTIFIED_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "NotIdentified":
+        if not event.data:
+            return NotIdentified()
+
+        return NotIdentified(context=event.data.get("context"))

--- a/wyoming/identity.py
+++ b/wyoming/identity.py
@@ -9,6 +9,10 @@ DOMAIN = "identity"
 _IDENTIFY_TYPE = "identify"
 _IDENTIFIED_TYPE = "identified"
 _NOT_IDENTIFIED_TYPE = "not-identified"
+_ENROLL_TYPE = "enroll"
+_ENROLLED_TYPE = "enrolled"
+_DELETE_TYPE = "delete"
+_DELETED_TYPE = "deleted"
 
 
 @dataclass
@@ -111,3 +115,148 @@ class NotIdentified(Eventable):
             return NotIdentified()
 
         return NotIdentified(context=event.data.get("context"))
+
+
+@dataclass
+class Enroll(Eventable):
+    """Request to enroll an identity from an audio stream.
+
+    Followed by AudioStart, AudioChunk+, AudioStop
+    """
+
+    name: str
+    """Name/id of identity to enroll."""
+
+    model: Optional[str] = None
+    """Name of identity recognition model to update."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context from previous interactions."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _ENROLL_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.model is not None:
+            data["model"] = self.model
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_ENROLL_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Enroll":
+        data = event.data or {}
+        return Enroll(
+            name=data["name"],
+            model=data.get("model"),
+            context=data.get("context"),
+        )
+
+
+@dataclass
+class Enrolled(Eventable):
+    """Identity was enrolled."""
+
+    name: str
+    """Name/id of enrolled identity."""
+
+    model: Optional[str] = None
+    """Name of identity recognition model that was updated."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context for next interaction."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _ENROLLED_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.model is not None:
+            data["model"] = self.model
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_ENROLLED_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Enrolled":
+        return Enrolled(
+            name=event.data["name"],
+            model=event.data.get("model"),
+            context=event.data.get("context"),
+        )
+
+
+@dataclass
+class Delete(Eventable):
+    """Request to delete an enrolled identity."""
+
+    name: str
+    """Name/id of identity to delete."""
+
+    model: Optional[str] = None
+    """Name of identity recognition model to update."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context from previous interactions."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _DELETE_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.model is not None:
+            data["model"] = self.model
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_DELETE_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Delete":
+        data = event.data or {}
+        return Delete(
+            name=data["name"],
+            model=data.get("model"),
+            context=data.get("context"),
+        )
+
+
+@dataclass
+class Deleted(Eventable):
+    """Identity was deleted."""
+
+    name: str
+    """Name/id of deleted identity."""
+
+    model: Optional[str] = None
+    """Name of identity recognition model that was updated."""
+
+    context: Optional[Dict[str, Any]] = None
+    """Context for next interaction."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _DELETED_TYPE
+
+    def event(self) -> Event:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.model is not None:
+            data["model"] = self.model
+        if self.context is not None:
+            data["context"] = self.context
+
+        return Event(type=_DELETED_TYPE, data=data)
+
+    @staticmethod
+    def from_event(event: Event) -> "Deleted":
+        return Deleted(
+            name=event.data["name"],
+            model=event.data.get("model"),
+            context=event.data.get("context"),
+        )

--- a/wyoming/info.py
+++ b/wyoming/info.py
@@ -118,6 +118,33 @@ class TtsProgram(Artifact):
 
 
 @dataclass
+class Identity(DataClassJsonMixin):
+    """Enrolled identity."""
+
+    name: str
+    """Name/id of identity."""
+
+
+@dataclass
+class IdentityModel(Artifact):
+    """Identity recognition model."""
+
+    identities: Optional[List[Identity]] = None
+    """List of enrolled identities."""
+
+
+@dataclass
+class IdentityProgram(Artifact):
+    """Identity recognition service."""
+
+    models: List[IdentityModel]
+    """List of available models."""
+
+
+# -----------------------------------------------------------------------------
+
+
+@dataclass
 class HandleModel(Artifact):
     """Intent handling model."""
 
@@ -235,6 +262,9 @@ class Info(Eventable):
     tts: List[TtsProgram] = field(default_factory=list)
     """Text-to-speech services."""
 
+    identity: List[IdentityProgram] = field(default_factory=list)
+    """Identity recognition services."""
+
     handle: List[HandleProgram] = field(default_factory=list)
     """Intent handling services."""
 
@@ -261,6 +291,7 @@ class Info(Eventable):
         data: Dict[str, Any] = {
             "asr": [p.to_dict() for p in self.asr],
             "tts": [p.to_dict() for p in self.tts],
+            "identity": [p.to_dict() for p in self.identity],
             "handle": [p.to_dict() for p in self.handle],
             "intent": [p.to_dict() for p in self.intent],
             "wake": [p.to_dict() for p in self.wake],
@@ -283,6 +314,9 @@ class Info(Eventable):
         return Info(
             asr=[AsrProgram.from_dict(d) for d in event.data.get("asr", [])],
             tts=[TtsProgram.from_dict(d) for d in event.data.get("tts", [])],
+            identity=[
+                IdentityProgram.from_dict(d) for d in event.data.get("identity", [])
+            ],
             handle=[HandleProgram.from_dict(d) for d in event.data.get("handle", [])],
             intent=[IntentProgram.from_dict(d) for d in event.data.get("intent", [])],
             wake=[WakeProgram.from_dict(d) for d in event.data.get("wake", [])],

--- a/wyoming/pipeline.py
+++ b/wyoming/pipeline.py
@@ -15,6 +15,9 @@ class PipelineStage(str, Enum):
     WAKE = "wake"
     """Wake word detection."""
 
+    IDENTITY = "identity"
+    """Identity recognition."""
+
     ASR = "asr"
     """Speech-to-text (a.k.a. automated speech recognition)."""
 
@@ -41,6 +44,9 @@ class RunPipeline(Eventable):
     wake_word_name: Optional[str] = None
     """Name of wake word that triggered this pipeline."""
 
+    identity_name: Optional[str] = None
+    """Name of identity recognized during this pipeline."""
+
     restart_on_end: bool = False
     """True if pipeline should restart automatically after ending."""
 
@@ -57,6 +63,16 @@ class RunPipeline(Eventable):
         if self.start_stage == PipelineStage.WAKE:
             if self.end_stage not in (
                 PipelineStage.WAKE,
+                PipelineStage.IDENTITY,
+                PipelineStage.ASR,
+                PipelineStage.INTENT,
+                PipelineStage.HANDLE,
+                PipelineStage.TTS,
+            ):
+                end_valid = False
+        elif self.start_stage == PipelineStage.IDENTITY:
+            if self.end_stage not in (
+                PipelineStage.IDENTITY,
                 PipelineStage.ASR,
                 PipelineStage.INTENT,
                 PipelineStage.HANDLE,
@@ -66,6 +82,7 @@ class RunPipeline(Eventable):
         elif self.start_stage == PipelineStage.ASR:
             if self.end_stage not in (
                 PipelineStage.ASR,
+                PipelineStage.IDENTITY,
                 PipelineStage.INTENT,
                 PipelineStage.HANDLE,
                 PipelineStage.TTS,
@@ -110,6 +127,9 @@ class RunPipeline(Eventable):
         if self.wake_word_name is not None:
             data["wake_word_name"] = self.wake_word_name
 
+        if self.identity_name is not None:
+            data["identity_name"] = self.identity_name
+
         if self.wake_word_names:
             data["wake_word_names"] = self.wake_word_names
 
@@ -124,6 +144,7 @@ class RunPipeline(Eventable):
             start_stage=PipelineStage(event.data["start_stage"]),
             end_stage=PipelineStage(event.data["end_stage"]),
             wake_word_name=event.data.get("wake_word_name"),
+            identity_name=event.data.get("identity_name"),
             restart_on_end=event.data.get("restart_on_end", False),
             wake_word_names=event.data.get("wake_word_names"),
             announce_text=event.data.get("announce_text"),


### PR DESCRIPTION
This PR introduces a new service to the protocol: `identity`.

This service should run at the same time as `asr` and provide the context of who is talking to the intent parser and handler. This will allow for per user aliases (e.g. "My bedside light"), and tentatively permission handling.

My current thoughts on the concurrency is: Home Assistant will call this service asynchronously next to the `asr` and this will be handled outside of the standard pipeline order.