### PR TITLE
Fix CLOSE_WAIT socket leak: close StreamWriter on client disconnect

### DIFF
--- a/wyoming/server.py
+++ b/wyoming/server.py
@@ -42,6 +42,7 @@ class AsyncEventHandler(ABC):
                     break
         finally:
             await self.disconnect()
+            self.writer.close()
 
     async def disconnect(self) -> None:
         """Called when client disconnects."""


### PR DESCRIPTION
## Summary

`AsyncEventHandler.run()` never closes the `StreamWriter` when a client disconnects, causing TCP sockets to leak in `CLOSE_WAIT` state.

## Problem

When a client disconnects from a Wyoming TCP server:

1. `async_read_event()` returns `None` (EOF), breaking the `while` loop in `run()`
2. The `finally` block calls `self.disconnect()` — which is an empty no-op
3. The handler task completes and is removed from `_handlers`
4. **But `self.writer` is never closed**

The only place `writer.close()` is called is in `stop()`, which only runs during full server shutdown — not when individual clients disconnect normally.

This leaves the server-side TCP socket in `CLOSE_WAIT` indefinitely. Over time, these leaked sockets accumulate until the server becomes unresponsive and must be restarted.

## Evidence

Observed running `wyoming-piper` (2.2.2) and `wyoming-mlx-whisper` (1.4.0) as Wyoming Protocol integrations serving Home Assistant voice pipelines:

```
# After ~2 hours of normal voice assistant use:
$ netstat -an | grep 10300 | grep CLOSE_WAIT | wc -l
      15
$ netstat -an | grep 10200 | grep CLOSE_WAIT | wc -l
       7
```

All `CLOSE_WAIT` connections originated from the Home Assistant host, which properly closes its side after each pipeline run.

After applying this one-line fix and restarting both services:

```
# After 5 consecutive pipeline runs:
$ netstat -an | grep 10300 | grep CLOSE_WAIT | wc -l
       0
$ netstat -an | grep 10200 | grep CLOSE_WAIT | wc -l
       0
```

## Fix

Add `self.writer.close()` in `run()`'s `finally` block, immediately after the `disconnect()` call. This ensures the server properly closes its end of the TCP connection whenever a client disconnects, regardless of whether `disconnect()` is overridden by subclasses.

## Notes

- The fix is intentionally in `run()` rather than in `disconnect()` so that subclass overrides of `disconnect()` don't need to remember to call `super().disconnect()` or close the writer themselves.
- `stop()` also calls `writer.close()`, but calling close on an already-closed writer is safe (it's a no-op).