### PR TITLE
implement a websocket transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "wyoming"
 version = "1.9.0"
 description = "Peer-to-peer protocol for voice assistants"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8.1"
 license = {text = "MIT"}
 authors = [
     {name = "Michael Hansen", email = "mike@rhasspy.org"}
@@ -62,6 +62,9 @@ dev = [
 ]
 zeroconf = [
     "zeroconf==0.88.0"
+]
+websocket = [
+    "websockets>=12,<17"
 ]
 http = [
     "Flask[async]==3.0.2",

--- a/script/setup
+++ b/script/setup
@@ -14,6 +14,9 @@ parser.add_argument("--http", action="store_true", help="Install http requiremen
 parser.add_argument(
     "--zeroconf", action="store_true", help="Install zeroconf requirements"
 )
+parser.add_argument(
+    "--websocket", action="store_true", help="Install websocket requirements"
+)
 args = parser.parse_args()
 
 # Create virtual environment
@@ -36,6 +39,9 @@ if args.http:
 
 if args.zeroconf:
     extras.append("zeroconf")
+
+if args.websocket:
+    extras.append("websocket")
 
 extras_str = ""
 if extras:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from wyoming.client import (
     AsyncStdioClient,
     AsyncTcpClient,
     AsyncUnixClient,
+    AsyncWebSocketClient,
 )
 
 
@@ -37,3 +38,11 @@ def test_from_uri() -> None:
     unix_client = AsyncClient.from_uri("unix:///path/to/socket")
     assert isinstance(unix_client, AsyncUnixClient)
     assert unix_client.socket_path == Path("/path/to/socket")
+
+    ws_client = AsyncClient.from_uri("ws://127.0.0.1:5000")
+    assert isinstance(ws_client, AsyncWebSocketClient)
+    assert ws_client.uri == "ws://127.0.0.1:5000"
+
+    wss_client = AsyncClient.from_uri("wss://example.com/stream")
+    assert isinstance(wss_client, AsyncWebSocketClient)
+    assert wss_client.uri == "wss://example.com/stream"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from wyoming.server import (
     AsyncStdioServer,
     AsyncTcpServer,
     AsyncUnixServer,
+    AsyncWebSocketServer,
 )
 
 
@@ -54,6 +55,15 @@ def test_from_uri() -> None:
     unix_server = AsyncServer.from_uri("unix:///path/to/socket")
     assert isinstance(unix_server, AsyncUnixServer)
     assert unix_server.socket_path == Path("/path/to/socket")
+
+    # Missing port
+    with pytest.raises(ValueError):
+        AsyncServer.from_uri("ws://127.0.0.1")
+
+    ws_server = AsyncServer.from_uri("ws://127.0.0.1:5000")
+    assert isinstance(ws_server, AsyncWebSocketServer)
+    assert ws_server.host == "127.0.0.1"
+    assert ws_server.port == 5000
 
 
 @pytest.mark.asyncio
@@ -116,3 +126,40 @@ async def test_tcp_server() -> None:
 
     await client.disconnect()
     await tcp_server.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_server() -> None:
+    """Test sending events to and from a WebSocket server."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    port = sock.getsockname()[1]
+    sock.close()
+
+    uri = f"ws://127.0.0.1:{port}"
+
+    ws_server = AsyncServer.from_uri(uri)
+    await ws_server.start(PingHandler)
+
+    # Wait for server to open
+    for _ in range(10):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(("127.0.0.1", port))
+            sock.close()
+            break
+        except ConnectionRefusedError:
+            await asyncio.sleep(0.1)
+
+    client = AsyncClient.from_uri(uri)
+    await client.connect()
+    await client.write_event(Ping(text="test").event())
+
+    event = await asyncio.wait_for(client.read_event(), timeout=1)
+    assert event is not None
+    assert Pong.is_type(event.type)
+    assert Pong.from_event(event).text == "test"
+
+    await client.disconnect()
+    await ws_server.stop()

--- a/wyoming/client.py
+++ b/wyoming/client.py
@@ -9,8 +9,15 @@ from .event import (
     async_get_stdin,
     async_get_stdout,
     async_read_event,
+    async_read_event_from_bytes,
     async_write_event,
+    event_to_bytes,
 )
+
+try:
+    import websockets
+except ImportError:
+    websockets = None  # type: ignore[assignment]
 
 
 class AsyncClient(ABC):
@@ -57,7 +64,12 @@ class AsyncClient(ABC):
         if result.scheme == "stdio":
             return AsyncStdioClient()
 
-        raise ValueError("Only 'stdio://', 'unix://', or 'tcp://' are supported")
+        if result.scheme == "ws" or result.scheme == "wss":
+            return AsyncWebSocketClient(uri)
+
+        raise ValueError(
+            "Only 'stdio://', 'unix://', 'tcp://', or 'ws://' are supported"
+        )
 
 
 class AsyncTcpClient(AsyncClient):
@@ -130,3 +142,46 @@ class AsyncStdioClient(AsyncClient):
 
         assert self._writer is not None
         await async_write_event(event, self._writer)
+
+
+class AsyncWebSocketClient(AsyncClient):
+    """WebSocket Wyoming client."""
+
+    def __init__(self, uri: str) -> None:
+        super().__init__()
+
+        self.uri = uri
+        self._websocket = None
+
+    async def connect(self) -> None:
+        if websockets is None:
+            raise RuntimeError("websockets is required for 'ws://' support")
+
+        self._websocket = await websockets.connect(
+            self.uri,
+        )
+
+    async def disconnect(self) -> None:
+        websocket = self._websocket
+        self._websocket = None
+
+        if websocket is not None:
+            await websocket.close()
+
+    async def read_event(self) -> Optional[Event]:
+        assert self._websocket is not None
+
+        try:
+            message = await self._websocket.recv()
+        except websockets.ConnectionClosed:
+            return None
+
+        return await async_read_event_from_bytes(message)
+
+    async def write_event(self, event: Event) -> None:
+        assert self._websocket is not None
+
+        try:
+            await self._websocket.send(event_to_bytes(event))
+        except websockets.ConnectionClosed:
+            pass

--- a/wyoming/event.py
+++ b/wyoming/event.py
@@ -4,7 +4,7 @@ import os
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, BinaryIO, Dict, Iterable, Optional
+from typing import Any, BinaryIO, Dict, Iterable, Optional, Union
 
 from .version import __version__
 
@@ -109,7 +109,8 @@ async def async_read_event(reader: asyncio.StreamReader) -> Optional[Event]:
     return None
 
 
-async def async_write_event(event: Event, writer: asyncio.StreamWriter):
+def event_to_bytes(event: Event) -> bytes:
+    """Serialize an event to bytes in the Wyoming protocol wire format."""
     event_dict: Dict[str, Any] = event.to_dict()
     event_dict[_VERSION] = _VERSION_NUMBER
 
@@ -124,15 +125,31 @@ async def async_write_event(event: Event, writer: asyncio.StreamWriter):
 
     json_line = json.dumps(event_dict, ensure_ascii=False)
 
+    parts = [json_line.encode(), _NEWLINE]
+    if data_bytes:
+        parts.append(data_bytes)
+
+    if event.payload:
+        parts.append(event.payload)
+
+    return b"".join(parts)
+
+
+async def async_read_event_from_bytes(data: Union[bytes, str]) -> Optional[Event]:
+    """Read a single event from bytes in the Wyoming protocol wire format."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+
+    return await async_read_event(reader)
+
+
+async def async_write_event(event: Event, writer: asyncio.StreamWriter):
     try:
-        writer.writelines((json_line.encode(), _NEWLINE))
-
-        if data_bytes:
-            writer.write(data_bytes)
-
-        if event.payload:
-            writer.write(event.payload)
-
+        writer.write(event_to_bytes(event))
         await writer.drain()
     except KeyboardInterrupt:
         pass

--- a/wyoming/server.py
+++ b/wyoming/server.py
@@ -6,17 +6,41 @@ from pathlib import Path
 from typing import Callable, Dict, Optional, Union
 from urllib.parse import urlparse
 
-from .event import Event, async_get_stdin, async_read_event, async_write_event
+from .event import (
+    Event,
+    async_get_stdin,
+    async_read_event,
+    async_read_event_from_bytes,
+    async_write_event,
+    event_to_bytes,
+)
+
+try:
+    import websockets
+except ImportError:
+    websockets = None  # type: ignore[assignment]
+
+
+class AsyncEventTransport(ABC):
+    """Reads and writes events over an underlying connection."""
+
+    @abstractmethod
+    async def read_event(self) -> Optional[Event]:
+        """Read the next event, or None if the connection is closed."""
+
+    @abstractmethod
+    async def write_event(self, event: Event) -> None:
+        """Write an event to the connection."""
+
+    async def close(self) -> None:
+        """Close the connection."""
 
 
 class AsyncEventHandler(ABC):
     """Base class for async Wyoming event handler."""
 
-    def __init__(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        self.reader = reader
-        self.writer = writer
+    def __init__(self, transport: AsyncEventTransport) -> None:
+        self._transport = transport
         self._is_running = False
 
     @abstractmethod
@@ -26,7 +50,7 @@ class AsyncEventHandler(ABC):
 
     async def write_event(self, event: Event) -> None:
         """Send an event to the client."""
-        await async_write_event(event, self.writer)
+        await self._transport.write_event(event)
 
     async def run(self) -> None:
         """Receive events until stopped or handle_event returns false."""
@@ -34,7 +58,7 @@ class AsyncEventHandler(ABC):
 
         try:
             while self._is_running:
-                event = await async_read_event(self.reader)
+                event = await self._transport.read_event()
                 if event is None:
                     break
 
@@ -42,7 +66,7 @@ class AsyncEventHandler(ABC):
                     break
         finally:
             await self.disconnect()
-            self.writer.close()
+            await self._transport.close()
 
     async def disconnect(self) -> None:
         """Called when client disconnects."""
@@ -50,13 +74,54 @@ class AsyncEventHandler(ABC):
     async def stop(self) -> None:
         """Try to stop the event handler."""
         self._is_running = False
-        self.writer.close()
-        self.reader.feed_eof()
+        await self._transport.close()
 
 
-HandlerFactory = Callable[
-    [asyncio.StreamReader, asyncio.StreamWriter], AsyncEventHandler
-]
+HandlerFactory = Callable[[AsyncEventTransport], AsyncEventHandler]
+
+
+class _StreamTransport(AsyncEventTransport):
+    """Event transport over asyncio streams."""
+
+    def __init__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+
+    async def read_event(self) -> Optional[Event]:
+        return await async_read_event(self._reader)
+
+    async def write_event(self, event: Event) -> None:
+        await async_write_event(event, self._writer)
+
+    async def close(self) -> None:
+        self._writer.close()
+        self._reader.feed_eof()
+
+
+class _WebSocketTransport(AsyncEventTransport):
+    """Event transport over a WebSocket connection."""
+
+    def __init__(self, websocket) -> None:
+        self._websocket = websocket
+
+    async def read_event(self) -> Optional[Event]:
+        try:
+            message = await self._websocket.recv()
+        except websockets.ConnectionClosed:
+            return None
+
+        return await async_read_event_from_bytes(message)
+
+    async def write_event(self, event: Event) -> None:
+        try:
+            await self._websocket.send(event_to_bytes(event))
+        except websockets.ConnectionClosed:
+            pass
+
+    async def close(self) -> None:
+        await self._websocket.close()
 
 
 class AsyncServer(ABC):
@@ -86,18 +151,32 @@ class AsyncServer(ABC):
         if result.scheme == "stdio":
             return AsyncStdioServer()
 
-        raise ValueError("Only 'stdio://', 'unix://', or 'tcp://' are supported")
+        if result.scheme == "ws":
+            if (result.hostname is None) or (result.port is None):
+                raise ValueError("A port must be specified when using a 'ws://' URI")
 
-    async def _handler_callback(
+            return AsyncWebSocketServer(result.hostname, result.port)
+
+        raise ValueError(
+            "Only 'stdio://', 'unix://', 'tcp://', or 'ws://' are supported"
+        )
+
+    async def _run_handler(
+        self, handler_factory: HandlerFactory, transport: AsyncEventTransport
+    ) -> None:
+        handler = handler_factory(transport)
+        task = asyncio.create_task(handler.run(), name="wyoming event handler")
+        self._handlers[task] = handler
+        task.add_done_callback(lambda t: self._handlers.pop(t, None))
+        await task
+
+    async def _run_stream_handler(
         self,
         handler_factory: HandlerFactory,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ):
-        handler = handler_factory(reader, writer)
-        task = asyncio.create_task(handler.run(), name="wyoming event handler")
-        self._handlers[task] = handler
-        task.add_done_callback(lambda t: self._handlers.pop(t, None))
+        await self._run_handler(handler_factory, _StreamTransport(reader, writer))
 
     async def start(self, handler_factory: HandlerFactory) -> None:
         """Start server without blocking."""
@@ -122,14 +201,8 @@ class AsyncStdioServer(AsyncServer):
         )
         writer = asyncio.StreamWriter(writer_transport, writer_protocol, None, loop)
 
-        handler = handler_factory(reader, writer)
-        while True:
-            event = await async_read_event(reader)
-            if event is None:
-                break
-
-            if not (await handler.handle_event(event)):
-                break
+        handler = handler_factory(_StreamTransport(reader, writer))
+        await handler.run()
 
 
 class AsyncTcpServer(AsyncServer):
@@ -142,7 +215,7 @@ class AsyncTcpServer(AsyncServer):
         self._server: Optional[asyncio.AbstractServer] = None
 
     async def run(self, handler_factory: HandlerFactory) -> None:
-        handler_callback = partial(self._handler_callback, handler_factory)
+        handler_callback = partial(self._run_stream_handler, handler_factory)
         self._server = await asyncio.start_server(
             handler_callback, host=self.host, port=self.port
         )
@@ -151,7 +224,7 @@ class AsyncTcpServer(AsyncServer):
 
     async def start(self, handler_factory: HandlerFactory) -> None:
         """Start server without blocking."""
-        handler_callback = partial(self._handler_callback, handler_factory)
+        handler_callback = partial(self._run_stream_handler, handler_factory)
         self._server = await asyncio.start_server(
             handler_callback, host=self.host, port=self.port
         )
@@ -179,7 +252,7 @@ class AsyncUnixServer(AsyncServer):
         # Need to unlink socket file if it exists
         self.socket_path.unlink(missing_ok=True)
 
-        handler_callback = partial(self._handler_callback, handler_factory)
+        handler_callback = partial(self._run_stream_handler, handler_factory)
         self._server = await asyncio.start_unix_server(
             handler_callback, path=self.socket_path
         )
@@ -195,7 +268,7 @@ class AsyncUnixServer(AsyncServer):
         # Need to unlink socket file if it exists
         self.socket_path.unlink(missing_ok=True)
 
-        handler_callback = partial(self._handler_callback, handler_factory)
+        handler_callback = partial(self._run_stream_handler, handler_factory)
         self._server = await asyncio.start_unix_server(
             handler_callback, path=self.socket_path
         )
@@ -210,3 +283,50 @@ class AsyncUnixServer(AsyncServer):
             self._server.close()
 
         self.socket_path.unlink(missing_ok=True)
+
+
+class AsyncWebSocketServer(AsyncServer):
+    """Wyoming server over WebSocket."""
+
+    def __init__(self, host: str, port: int) -> None:
+        super().__init__()
+        self.host = host
+        self.port = port
+        self._server: Optional["websockets.asyncio.server.Server"] = None
+
+    async def run(self, handler_factory: HandlerFactory) -> None:
+        """Start server and block while running."""
+        if websockets is None:
+            raise RuntimeError("websockets is required for 'ws://' support")
+
+        self._server = await websockets.serve(
+            partial(self._ws_callback, handler_factory),
+            host=self.host,
+            port=self.port,
+        )
+
+        await self._server.serve_forever()
+
+    async def start(self, handler_factory: HandlerFactory) -> None:
+        """Start server without blocking."""
+        if websockets is None:
+            raise RuntimeError("websockets is required for 'ws://' support")
+
+        self._server = await websockets.serve(
+            partial(self._ws_callback, handler_factory),
+            host=self.host,
+            port=self.port,
+        )
+
+        await self._server.start_serving()
+
+    async def stop(self) -> None:
+        """Try to stop all event handlers."""
+        await super().stop()
+
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _ws_callback(self, handler_factory: HandlerFactory, websocket) -> None:
+        await self._run_handler(handler_factory, _WebSocketTransport(websocket))


### PR DESCRIPTION
allow listening on `ws:` uris, and connecting a client to `ws:` or `wss:` uris. this allows much more flexible deployment of the server and lets users easily add in authentication and encryption as needed via reverse proxies.

my setup as an example:
i have a server which runs whisper and piper, and this is shared between my home and a friend's home. currently we have to connect to the two services by ip using different ports. the connection is also not encrypted, so our conversations are sent in plaintext over the internet.

with websocket transport, we could configure `whisper.example.com` and `piper.example.com` in a reverse proxy like caddy/nginx/etc. this would provide tls, and we could also use the reverse proxy to provide an authentication layer (e.g. by a `?token` query parameter or similar).