### PR TITLE
1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-- Add `text_format` so `synthesize` and `synthesize-start` (e.g., for "ssml")
 - Add VAD and audio preferences to ASR program
-- Add `vad_sensitivity` to `transcribe`
 - Add `select-program` to choose a program by name for the lifetime of a connection (defaults to the first program of each type)
+- Add `vad_sensitivity`, `transcript_names`, and `transcript_terms` to `transcribe`
+- Add `text_format` so `synthesize` and `synthesize-start` (e.g., for "ssml")
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `text_format` so `synthesize` and `synthesize-start` (e.g., for "ssml")
 - Add VAD and audio preferences to ASR program
 - Add `vad_sensitivity` to `transcribe`
+- Add `select-program` to choose a program by name for the lifetime of a connection (defaults to the first program of each type)
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.10.0
 
 - Add VAD and audio preferences to ASR program
 - Add `select-program` to choose a program by name for the lifetime of a connection (defaults to the first program of each type)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,14 @@ Describe available services.
             * `rate` - sample rate in hertz (int, required)
             * `width` - sample width in bytes (int, required)
             * `channels` - number of channels (int, required)
-    
+* `select-program` - selects which program handles the connection (optional)
+    * `name` - name of the program to use, matching a program `name` from `info` (string, required)
+    * Sent after connecting, before the first request event (e.g. `describe`, `transcribe`, `synthesize`, `detect`, `recognize`)
+    * Applies for the lifetime of the connection
+    * The domain (asr, tts, ...) is implied by the request events that follow, so `name` only needs to be unique within a domain
+    * If not sent, the first program of each type in `info` is used
+    * Servers are expected to drop unrecognized events, so sending this to a server that predates it is a no-op (the default program is used)
+
 ### Speech Recognition
 
 Transcribe audio into text.
@@ -346,6 +353,16 @@ Pipelines are run on the server, but can be triggered remotely from the server a
 
 1. &rarr; `describe` (required) 
 2. &larr; `info` (required)
+
+
+### Program Selection
+
+When an endpoint exposes more than one program of a type (e.g. multiple `asr`
+programs), select one for the connection before the request events below:
+
+1. &rarr; `select-program` with `name` of the program to use (optional)
+    * Omit to use the first program of each type in `info`
+2. &rarr; request events for the chosen program (e.g. `transcribe`, `synthesize`, `detect`, `recognize`)
 
 
 ### Speech to Text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyoming"
-version = "1.9.0"
+version = "1.10.0"
 description = "Peer-to-peer protocol for voice assistants"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_eventable.py
+++ b/tests/test_eventable.py
@@ -236,6 +236,8 @@ TEST_DATA: Dict[str, Dict[str, Any]] = {
         "context": TEST_CONTEXT,
         "language": TEST_LANGUAGE,
         "vad_sensitivity": "default",
+        "transcript_names": ["EcoBee"],
+        "transcript_terms": ["pause"],
     },
     "Transcript": {
         "text": TEST_TEXT,

--- a/tests/test_eventable.py
+++ b/tests/test_eventable.py
@@ -75,6 +75,7 @@ TEST_ATTRIBUTION = Attribution(name=TEST_NAME, url=TEST_URL)
 TEST_DATA: Dict[str, Dict[str, Any]] = {
     # info
     "Describe": {},
+    "SelectProgram": {"name": TEST_NAME},
     "Info": {
         "asr": [
             AsrProgram(

--- a/wyoming/asr.py
+++ b/wyoming/asr.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from .event import Event, Eventable
 
@@ -77,6 +77,18 @@ class Transcribe(Eventable):
     vad_sensitivity: Optional[Union[str, VadSensitivity]] = None
     """How quickly the end of a voice command is detected."""
 
+    transcript_names: Optional[List[str]] = None
+    """Unique names that should bias the ASR transcription.
+
+    These take priority over terms.
+    """
+
+    transcript_terms: Optional[List[str]] = None
+    """Domain-specific terms that should bias the ASR transcription.
+
+    These are lower priority than names.
+    """
+
     @staticmethod
     def is_type(event_type: str) -> bool:
         return event_type == _TRANSCRIBE_TYPE
@@ -97,6 +109,12 @@ class Transcribe(Eventable):
         elif self.vad_sensitivity is not None:
             data["vad_sensitivity"] = self.vad_sensitivity
 
+        if self.transcript_names is not None:
+            data["transcript_names"] = self.transcript_names
+
+        if self.transcript_terms is not None:
+            data["transcript_terms"] = self.transcript_terms
+
         return Event(type=_TRANSCRIBE_TYPE, data=data)
 
     @staticmethod
@@ -116,6 +134,8 @@ class Transcribe(Eventable):
             language=data.get("language"),
             context=data.get("context"),
             vad_sensitivity=vad_sensitivity,
+            transcript_names=data.get("transcript_names"),
+            transcript_terms=data.get("transcript_terms"),
         )
 
 

--- a/wyoming/info.py
+++ b/wyoming/info.py
@@ -10,6 +10,7 @@ from .util.dataclasses_json import DataClassJsonMixin
 DOMAIN = "info"
 _DESCRIBE_TYPE = "describe"
 _INFO_TYPE = "info"
+_SELECT_PROGRAM_TYPE = "select-program"
 
 
 @dataclass
@@ -26,6 +27,37 @@ class Describe(Eventable):
     @staticmethod
     def from_event(event: Event) -> "Describe":
         return Describe()
+
+
+@dataclass
+class SelectProgram(Eventable):
+    """Select which program handles this connection.
+
+    Sent by the client after connecting, before the first request event (e.g.,
+    describe/transcribe/synthesize/detect/recognize). Selects one of the
+    programs advertised in the info message by name for the lifetime of the
+    connection. The domain (asr, tts, ...) is implied by the request events
+    that follow, so ``name`` only needs to be unique within a domain.
+
+    If this event is not sent, the first program of each type in the info
+    message is used. Servers are expected to drop unrecognized events, so
+    sending this to a server that predates it is a no-op (the default program
+    is used).
+    """
+
+    name: str
+    """Name of the program to use (matches a program name in the info message)."""
+
+    @staticmethod
+    def is_type(event_type: str) -> bool:
+        return event_type == _SELECT_PROGRAM_TYPE
+
+    def event(self) -> Event:
+        return Event(type=_SELECT_PROGRAM_TYPE, data={"name": self.name})
+
+    @staticmethod
+    def from_event(event: Event) -> "SelectProgram":
+        return SelectProgram(name=event.data["name"])
 
 
 @dataclass


### PR DESCRIPTION
- Add VAD and audio preferences to ASR program
- Add `select-program` to choose a program by name for the lifetime of a connection (defaults to the first program of each type)
- Add `vad_sensitivity`, `transcript_names`, and `transcript_terms` to `transcribe`
- Add `text_format` so `synthesize` and `synthesize-start` (e.g., for "ssml")
